### PR TITLE
fix(cli): prevents next step until an available commit type is selected

### DIFF
--- a/cmd/tui.go
+++ b/cmd/tui.go
@@ -202,6 +202,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch m.viewing {
 			default:
 				m = m.submit().advance()
+			case commitTypeIndex:
+				if m.currentComponent().Value() == "" {
+					return m, cmd
+				} else {
+					m = m.submit().advance()
+				}
 			case scopeIndex:
 				if m.currentComponent().Value() == "new scope" {
 					m.scopeInput, cmd = m.scopeInput.Update(msg)


### PR DESCRIPTION
Hi,

Recently, I started using git-cc and I'm really enjoying it. I've found a behavior that I don't know if is intended.

When a invalid commit type (a commit type that is not listed in the option list) is selected,  user can still advances to the next screen and then to the next. But after confirming, user returns to the initial screen.

With this PR, user can only advance to the select commit scope screen when a valid commit type was selected in the previous screen.